### PR TITLE
fix: use as_chunk instead of as_paragraph when adding chunks

### DIFF
--- a/R/as_flextable.cond_indirect_effects.R
+++ b/R/as_flextable.cond_indirect_effects.R
@@ -407,8 +407,7 @@ as_flextable.cond_indirect_effects <- function(x,
           }
         if (!all_w_categorical(x) && !all_w_numeric((x))) {
             ft <- flextable::append_chunks(ft,
-                    flextable::as_chunk("[w] is the meaning of a level of moderator 'w' ",
-                                            "or the label of a group in moderator 'w'"),
+                    flextable::as_chunk("[w] is the meaning of a level of moderator 'w' or the label of a group in moderator 'w'"),
                     part = "footer")
           }
         first_note <- FALSE
@@ -446,17 +445,17 @@ as_flextable.cond_indirect_effects <- function(x,
             if (first_note) {
                 first_note <- FALSE
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_chunk(flextable::as_i("P ")),
+                        flextable::as_i("P "),
                         part = "footer")
               } else {
                 ft <- flextable::append_chunks(ft,
                         flextable::as_chunk("; "),
-                        flextable::as_chunk(flextable::as_i("p ")),
+                        flextable::as_i("p "),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
                     flextable::as_chunk("is asymmetric bootstrap "),
-                    flextable::as_chunk(flextable::as_i("p")),
+                    flextable::as_i("p"),
                     flextable::as_chunk("-value"),
                     part = "footer")
           }

--- a/R/as_flextable.cond_indirect_effects.R
+++ b/R/as_flextable.cond_indirect_effects.R
@@ -393,21 +393,21 @@ as_flextable.cond_indirect_effects <- function(x,
                 value = flextable::as_paragraph(flextable::as_i("Note")),
                 part = "footer")
         ft <- flextable::append_chunks(ft,
-                flextable::as_paragraph(": "),
+                flextable::as_chunk(": "),
                 part = "footer")
         if (all_w_numeric(x)) {
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("[w] is the meaning of a level of moderator 'w'"),
+                    flextable::as_chunk("[w] is the meaning of a level of moderator 'w'"),
                     part = "footer")
           }
         if (all_w_categorical(x)) {
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("[w] is the label of a group in moderator 'w'"),
+                    flextable::as_chunk("[w] is the label of a group in moderator 'w'"),
                     part = "footer")
           }
         if (!all_w_categorical(x) && !all_w_numeric((x))) {
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("[w] is the meaning of a level of moderator 'w' ",
+                    flextable::as_chunk("[w] is the meaning of a level of moderator 'w' ",
                                             "or the label of a group in moderator 'w'"),
                     part = "footer")
           }
@@ -417,18 +417,16 @@ as_flextable.cond_indirect_effects <- function(x,
                 first_note <- FALSE
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("; "),
+                        flextable::as_chunk("; "),
                         part = "footer")
               }
             if (is.null(get_indicators(x)) || !show_indicators) {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("(w) is the value of a level ",
-                                                 "of moderator 'w'"),
+                        flextable::as_chunk("(w) is the value of a level of moderator 'w'"),
                         part = "footer")
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("(w) is the value of a level ",
-                                                 "of moderator 'w', or its indicators if 'w' is categorical"),
+                        flextable::as_chunk("(w) is the value of a level of moderator 'w', or its indicators if 'w' is categorical"),
                         part = "footer")
               }
           }
@@ -437,29 +435,29 @@ as_flextable.cond_indirect_effects <- function(x,
                 first_note <- FALSE
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph(": "),
+                        flextable::as_chunk(": "),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("CI = confidence interval"),
+                    flextable::as_chunk("CI = confidence interval"),
                     part = "footer")
           }
         if (has_pvalue) {
             if (first_note) {
                 first_note <- FALSE
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph(flextable::as_i("P ")),
+                        flextable::as_chunk(flextable::as_i("P ")),
                         part = "footer")
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("; "),
-                        flextable::as_paragraph(flextable::as_i("p ")),
+                        flextable::as_chunk("; "),
+                        flextable::as_chunk(flextable::as_i("p ")),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("is asymmetric bootstrap "),
-                    flextable::as_paragraph(flextable::as_i("p")),
-                    flextable::as_paragraph("-value"),
+                    flextable::as_chunk("is asymmetric bootstrap "),
+                    flextable::as_chunk(flextable::as_i("p")),
+                    flextable::as_chunk("-value"),
                     part = "footer")
           }
         if (isTRUE(xor(std_x, std_y))) {
@@ -467,16 +465,16 @@ as_flextable.cond_indirect_effects <- function(x,
                 first_note <- FALSE
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("; "),
+                        flextable::as_chunk("; "),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("Std. Effect is partially standardized effect, "),
-                    flextable::as_paragraph("with ",
+                    flextable::as_chunk("Std. Effect is partially standardized effect, "),
+                    flextable::as_chunk(paste0("with ",
                                             ifelse(std_x,
                                                    "the predictor",
                                                    "the outcome"),
-                                            " standardized"),
+                                            " standardized")),
                     part = "footer")
           }
         if (std_x && std_y) {
@@ -484,15 +482,15 @@ as_flextable.cond_indirect_effects <- function(x,
                 first_note <- FALSE
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("; "),
+                        flextable::as_chunk("; "),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("Std. Effect is completely standardized effect"),
+                    flextable::as_chunk("Std. Effect is completely standardized effect"),
                     part = "footer")
           }
         ft <- flextable::append_chunks(ft,
-                flextable::as_paragraph("."),
+                flextable::as_chunk("."),
                 part = "footer")
       }
 

--- a/R/as_flextable.indirect_list.R
+++ b/R/as_flextable.indirect_list.R
@@ -379,42 +379,42 @@ as_flextable.indirect_list <- function(x,
                 value = flextable::as_paragraph(flextable::as_i("Note")),
                 part = "footer")
         ft <- flextable::append_chunks(ft,
-                flextable::as_paragraph(": "),
+                flextable::as_chunk(": "),
                 part = "footer")
         if (has_ci) {
             first_note <- FALSE
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("CI = confidence interval"),
+                    flextable::as_chunk("CI = confidence interval"),
                     part = "footer")
           }
         if (has_pvalue) {
             first_note <- FALSE
             if (first_note) {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph(flextable::as_i("P ")),
+                        flextable::as_chunk(flextable::as_i("P ")),
                         part = "footer")
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("; "),
-                        flextable::as_paragraph(flextable::as_i("p ")),
+                        flextable::as_chunk("; "),
+                        flextable::as_chunk(flextable::as_i("p ")),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("is asymmetric bootstrap "),
-                    flextable::as_paragraph(flextable::as_i("p")),
-                    flextable::as_paragraph("-value"),
+                    flextable::as_chunk("is asymmetric bootstrap "),
+                    flextable::as_i("p"),
+                    flextable::as_chunk("-value"),
                     part = "footer")
           }
         if (total_indirect) {
             first_note <- FALSE
             if (first_note) {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("Paths with '..' are total indirect effects"),
+                        flextable::as_chunk("Paths with '..' are total indirect effects"),
                         part = "footer")
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("; "),
-                        flextable::as_paragraph("paths with '..' are total indirect effects"),
+                        flextable::as_chunk("; "),
+                        flextable::as_chunk("paths with '..' are total indirect effects"),
                         part = "footer")
               }
           }
@@ -423,12 +423,12 @@ as_flextable.indirect_list <- function(x,
             if (first_note) {
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("; "),
+                        flextable::as_chunk("; "),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("Std. Effect is partially standardized effect, "),
-                    flextable::as_paragraph("with ",
+                    flextable::as_chunk("Std. Effect is partially standardized effect, "),
+                    flextable::as_chunk("with ",
                                             ifelse(std_x,
                                                    "the predictor",
                                                    "the outcome"),
@@ -440,15 +440,15 @@ as_flextable.indirect_list <- function(x,
             if (first_note) {
               } else {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_paragraph("; "),
+                        flextable::as_chunk("; "),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
-                    flextable::as_paragraph("Std. Effect is completely standardized effect"),
+                    flextable::as_chunk("Std. Effect is completely standardized effect"),
                     part = "footer")
           }
         ft <- flextable::append_chunks(ft,
-                flextable::as_paragraph("."),
+                flextable::as_chunk("."),
                 part = "footer")
       }
 

--- a/R/as_flextable.indirect_list.R
+++ b/R/as_flextable.indirect_list.R
@@ -391,12 +391,12 @@ as_flextable.indirect_list <- function(x,
             first_note <- FALSE
             if (first_note) {
                 ft <- flextable::append_chunks(ft,
-                        flextable::as_chunk(flextable::as_i("P ")),
+                        flextable::as_i("P "),
                         part = "footer")
               } else {
                 ft <- flextable::append_chunks(ft,
                         flextable::as_chunk("; "),
-                        flextable::as_chunk(flextable::as_i("p ")),
+                        flextable::as_i("p "),
                         part = "footer")
               }
             ft <- flextable::append_chunks(ft,
@@ -428,11 +428,11 @@ as_flextable.indirect_list <- function(x,
               }
             ft <- flextable::append_chunks(ft,
                     flextable::as_chunk("Std. Effect is partially standardized effect, "),
-                    flextable::as_chunk("with ",
+                    flextable::as_chunk(paste0("with ",
                                             ifelse(std_x,
                                                    "the predictor",
                                                    "the outcome"),
-                                            " standardized"),
+                                            " standardized")),
                     part = "footer")
           }
         if (std_x && std_y) {


### PR DESCRIPTION
Hello,

After a code refactoring of 'flextable', we detected that your package uses `as_paragraph()` instead of `as_chunk()` as argument(s) to `append_chunks()`. This needs to be corrected to avoid a problem with the next version of flextable to be sent to CRAN (not for at least two weeks).

This PR fixes the issues.

KR,
David